### PR TITLE
Phase out ImgLib1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,6 @@
 			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>sc.fiji</groupId>
-			<artifactId>legacy-imglib1</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.jfree</groupId>
 			<artifactId>jcommon</artifactId>
 		</dependency>


### PR DESCRIPTION
We actually do not need to depend on ImgLib1 any longer... no code in SPIM Registration uses it.
