### PR TITLE
Proof-of-concept: support headless execution

### DIFF
--- a/src/main/java/spim/process/fusion/boundingbox/ManualBoundingBox.java
+++ b/src/main/java/spim/process/fusion/boundingbox/ManualBoundingBox.java
@@ -3,6 +3,7 @@ package spim.process.fusion.boundingbox;
 import ij.gui.GenericDialog;
 
 import java.awt.Choice;
+import java.awt.GraphicsEnvironment;
 import java.awt.Label;
 import java.awt.TextField;
 import java.awt.event.ItemEvent;
@@ -105,9 +106,11 @@ public class ManualBoundingBox extends BoundingBox
 		gd.addMessage( "???x???x??? pixels", GUIHelper.smallStatusFont, GUIHelper.good );
 		Label l2 = (Label)gd.getMessage();
 
-		final ManageListeners m = new ManageListeners( gd, gd.getNumericFields(), gd.getChoices(), l1, l2, fusion, fusion.supportsDownsampling(), fusion.supports16BitUnsigned() );
-		fusion.registerAdditionalListeners( m );
-		m.update();
+		if (GraphicsEnvironment.isHeadless()) {
+			final ManageListeners m = new ManageListeners( gd, gd.getNumericFields(), gd.getChoices(), l1, l2, fusion, fusion.supportsDownsampling(), fusion.supports16BitUnsigned() );
+			fusion.registerAdditionalListeners( m );
+			m.update();
+		}
 		
 		gd.showDialog();
 		


### PR DESCRIPTION
The dreaded (and frequently misunderstood) java.awt.HeadlessException occurs whenever code instantiates AWT components that contain text (and therefore need to access the XWindows server on Unix to figure out their dimensions).

In headless mode, it is therefore inappropriate to instantiate -- or access -- AWT components.

ImageJ2 has a had that can be activated using `--headless` that overrides the AWT instantiations in ImageJ 1.x' `GenericDialog` class, but of course that hack cannot fix callers.

This commit is a totally incomplete proof-of-concept: if you play funny games with listeners or AWT components (such as `Choice` or `TestField` instances), you *must* guard them against being effective in headless mode.

An even better idea may be to use `ij.IJ.isMacro()` as a guard: to install listeners or try to access graphical components is just useless churn when we are running in a macro anyway.